### PR TITLE
fix(docs): typo 'Drat' to 'Dart'

### DIFF
--- a/docs/tutorials/atsdk-tutorial/using-the-atsdk-with-dart.md
+++ b/docs/tutorials/atsdk-tutorial/using-the-atsdk-with-dart.md
@@ -8,7 +8,7 @@ description: >-
 
 ## What and why Dart ?
 
-&#x20;Dart is an opensource project from Google offering a fast and multi-platform programming language. The atPlatform team choose Dart as a high level language to build proof of concept code but Drat proved to be a fast and reliable language to build on and as we needed features like being able to compile to executables, the Dart team delivered.&#x20;
+&#x20;Dart is an opensource project from Google offering a fast and multi-platform programming language. The atPlatform team choose Dart as a high level language to build proof of concept code but Dart proved to be a fast and reliable language to build on and as we needed features like being able to compile to executables, the Dart team delivered.&#x20;
 
 At this point we have ported the atSDK to other languages, like Java and Python the Dart atSDK is a great place to start.&#x20;
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a typo that I found while reading the docs in this paragraph:
https://docs.atsign.com/tutorials/atsdk-tutorial/get-sample-code#open-source-on-github

**- How I did it**
Ancient magic powers.

**- How to verify it**
Check the updated spelling.

**- Description for the changelog**
Fixed a typo in the docs, from 'Drat' to 'Dart'.