### PR TITLE
build(deps): Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
#43 and #44 should have been grouped

**- What I did**

Added grouping to Dependabot config

**- How I did it**

Copied yaml from noports

**- How to verify it**

Will have to wait for another time when there are multiple actions updates

**- Description for the changelog**

build(deps): Group Dependabot updates